### PR TITLE
feat: #8 Select 공통 컴포넌트 구현

### DIFF
--- a/src/assets/icon/ArrowDown.svg
+++ b/src/assets/icon/ArrowDown.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 9L12 15L6 9" stroke="#CCD2E3" stroke-width="2"/>
+</svg>

--- a/src/assets/icon/ArrowUp.svg
+++ b/src/assets/icon/ArrowUp.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 15L12 9L6 15" stroke="#CCD2E3" stroke-width="2"/>
+</svg>

--- a/src/assets/icon/index.ts
+++ b/src/assets/icon/index.ts
@@ -2,3 +2,5 @@ export { ReactComponent as IconUser } from './User.svg';
 export { ReactComponent as IconBag } from './Bag.svg';
 export { ReactComponent as IconSearch } from './Search.svg';
 export { ReactComponent as IconClear } from './Clear.svg';
+export { ReactComponent as IconArrowDown } from './ArrowDown.svg';
+export { ReactComponent as IconArrowUp } from './ArrowUp.svg';

--- a/src/components/common/SelectBox/SelectBox.styles.tsx
+++ b/src/components/common/SelectBox/SelectBox.styles.tsx
@@ -1,0 +1,74 @@
+import styled from '@emotion/styled';
+
+import { theme } from '@/styles/theme';
+
+export const SelectContainer = styled.article`
+  width: var(--width);
+  height: var(--height);
+  ${theme.font.body1}
+  background-color: white;
+`;
+
+export const SelectedBox = styled.div`
+  width: 100%;
+  height: 100%;
+  border: 1px solid ${theme.color.black};
+  border-radius: 5px;
+  padding: 0 15px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: transparent;
+  cursor: pointer;
+  &.open {
+    border-radius: 5px 5px 0 0;
+    background-color: #ececec;
+  }
+`;
+
+export const OptionBox = styled.div`
+  width: 100%;
+  max-height: 150px;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  border: 1px solid ${theme.color.black};
+  border-top: none;
+  &::-webkit-scrollbar {
+    width: 5px;
+    border-radius: 10px;
+    &-thumb {
+      height: 30%;
+      background-color: #cacaca;
+      opacity: 0.5;
+      border-radius: 10px;
+    }
+    &-track {
+      background-color: #ebebeb;
+      opacity: 0.1;
+    }
+  }
+`;
+
+export const OptionUl = styled.ul`
+  width: 100%;
+  height: auto;
+  transition: all ease-in-out 1s;
+  > li {
+    width: 100%;
+    height: var(--height);
+    border-bottom: 1px solid #bbbbbb;
+    display: flex;
+    align-items: center;
+    padding: 0 15px;
+    text-overflow: ellipsis;
+    cursor: pointer;
+    &:hover {
+      /* background-color: #f1f1f1; */
+      background-color: ${theme.color.black};
+      color: ${theme.color.brand};
+    }
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+`;

--- a/src/components/common/SelectBox/SelectBox.tsx
+++ b/src/components/common/SelectBox/SelectBox.tsx
@@ -1,0 +1,64 @@
+import { CSSProperties, useState } from 'react';
+import { cx } from '@emotion/css';
+
+import Icon from '@/components/common/Icon';
+import * as S from '@/components/common/SelectBox/SelectBox.styles';
+
+interface SelectBoxProps {
+  width?: CSSProperties['width'];
+  height?: CSSProperties['height'];
+  optionList: string[];
+  onChange: (item: string) => void;
+  value: string | null;
+}
+
+function SelectBox({
+  width = '100%',
+  height = '30px',
+  optionList,
+  onChange,
+  value,
+}: SelectBoxProps) {
+  // 1. UI먼저 구현 ( 하드코딩 )
+  // 2. Box 클릭했을 때 option 오픈
+  // 3. option 클릭했을 때 선택부분 텍스트 변경, option 리스트 닫기
+  // 4. props값 받아서 전달하기
+  const [openOption, setOpenOption] = useState(false);
+
+  return (
+    <S.SelectContainer style={{ '--width': width, '--height': height } as CSSProperties}>
+      <S.SelectedBox
+        onClick={() => {
+          setOpenOption(!openOption);
+        }}
+        className={cx({
+          ['open']: openOption,
+        })}
+      >
+        {value || '선택'}
+        {openOption ? <Icon name="IconArrowUp" /> : <Icon name="IconArrowDown" />}
+      </S.SelectedBox>
+      {openOption && (
+        <S.OptionBox>
+          <S.OptionUl>
+            {optionList.map((item, index) => {
+              return (
+                <li
+                  key={index}
+                  onClick={() => {
+                    setOpenOption(false);
+                    onChange(item);
+                  }}
+                >
+                  {item}
+                </li>
+              );
+            })}
+          </S.OptionUl>
+        </S.OptionBox>
+      )}
+    </S.SelectContainer>
+  );
+}
+
+export default SelectBox;

--- a/src/components/common/commonUiTest/SelectTest.tsx
+++ b/src/components/common/commonUiTest/SelectTest.tsx
@@ -10,6 +10,7 @@ interface SampleItem {
 }
 
 const SelectTest = () => {
+  // 옵션으로 들어갈 배열
   const sampleArray = [
     '옵션1',
     '옵션2',
@@ -24,12 +25,15 @@ const SelectTest = () => {
     '옵션11',
     '옵션12',
   ];
+
+  // 결제할 또는 장바구니에 넣을 아이템의 정보들
   const [item, setItem] = useState<SampleItem>({
     productId: 123,
     quantity: 2,
     option: '',
   });
 
+  // Select컴포넌트에서 옵션이 바뀔때 마다 item의 정보를 업데이트 해줌
   const optionChangeHandler = useCallback((option: string) => {
     setItem({
       ...item,

--- a/src/components/common/commonUiTest/SelectTest.tsx
+++ b/src/components/common/commonUiTest/SelectTest.tsx
@@ -1,0 +1,62 @@
+import { useCallback, useState } from 'react';
+import styled from '@emotion/styled';
+
+import SelectBox from '@/components/common/SelectBox/SelectBox';
+
+interface SampleItem {
+  productId: number;
+  quantity: number;
+  option: string | null;
+}
+
+const SelectTest = () => {
+  const sampleArray = [
+    '옵션1',
+    '옵션2',
+    '옵션3',
+    '옵션4',
+    '옵션5',
+    '옵션6',
+    '옵션7',
+    '옵션8',
+    '옵션9',
+    '옵션10',
+    '옵션11',
+    '옵션12',
+  ];
+  const [item, setItem] = useState<SampleItem>({
+    productId: 123,
+    quantity: 2,
+    option: '',
+  });
+
+  const optionChangeHandler = useCallback((option: string) => {
+    setItem({
+      ...item,
+      option: option,
+    });
+  }, []);
+  console.log(item);
+  return (
+    <Container>
+      <Div>
+        <SelectBox optionList={sampleArray} onChange={optionChangeHandler} value={item.option} />
+      </Div>
+    </Container>
+  );
+};
+
+export default SelectTest;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding-top: 100px;
+  /* align-items: center; */
+`;
+
+const Div = styled.div`
+  width: 365px;
+`;


### PR DESCRIPTION
close #8 

## 💡 개요
![2023-09-01 17;38;40](https://github.com/supercoding-commerce/FE/assets/112530541/65f260b8-6e40-4e36-9d88-7d1bb18b063c)


## 📝 작업 내용
과정을 정해놓고 로직구현을 해보려고 노력했습니다!
1. UI 를 하드코딩으로 먼저 구현
2. SelectBox 클릭 시 option list가 오픈 됨
3. option 클릭 시 SelectBox 텍스트 변경, option list가 닫힘
4. 사용할 곳에서 props로 데이터 전달하기

- 확실히 해야할 순서가 정해져 있어서 집중해야할 기능구현을 알 수 있었습니다.
- select태그를 사용하면 스타일 커스텀이 어렵다고 하여 div와 ul, li를 활용하여 직접 구현했습니다.
- width 기본값 100%, height 기본값 30px 을 넣어놨고, 임의로 수정도 가능합니다.
- value값은 빈 string("") 이거나 null 이면 text로 "선택"을 보여줍니다.

## ‼️ 주의 사항
- 직접 구현한 부분이라 select에 있는 기본 기능들은 사용이 안됩니다.
- props의 optionList와 onChange함수, value값(빈 string, null 포함)을 넣어 주어야 에러가 나지 않습니다.

## 🔗 참고자료
