### PR TITLE
feat: #25 footer UI 구현

### DIFF
--- a/src/components/common/Footer/DefaultFooter.styles.tsx
+++ b/src/components/common/Footer/DefaultFooter.styles.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+
+import { theme } from '@/styles/theme';
+
+export const FooterContainer = styled.footer`
+  width: 100%;
+  height: 170px;
+  background-color: ${theme.color.black};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  padding: 25px 0;
+`;
+
+export const SnsIconsBox = styled.div`
+  width: 200px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  background-color: #4bffff;
+  /* TODO-yukddong : sns아이콘 찾으면 추가하고 배경색 지우기 */
+`;
+
+export const Logo = styled.h1`
+  color: ${theme.color.brand};
+  ${theme.font.h1}
+`;
+
+export const CopyRight = styled.p`
+  color: ${theme.color.backgroundColor};
+  ${theme.font.body3}
+`;

--- a/src/components/common/Footer/DefaultFooter.tsx
+++ b/src/components/common/Footer/DefaultFooter.tsx
@@ -1,0 +1,17 @@
+import * as S from '@/components/common/Footer/DefaultFooter.styles';
+
+const DefaultFooter = () => {
+  return (
+    <S.FooterContainer>
+      <S.SnsIconsBox>
+        <p>인스타</p>
+        <p>페북</p>
+        <p>유튜브</p>
+      </S.SnsIconsBox>
+      <S.Logo>로고</S.Logo>
+      <S.CopyRight> &#169; 2023 로오고 Corp. All rights reserved.</S.CopyRight>
+    </S.FooterContainer>
+  );
+};
+
+export default DefaultFooter;

--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -1,0 +1,28 @@
+import { useLocation } from 'react-router-dom';
+
+import DefaultFooter from '@/components/common/Footer/DefaultFooter';
+import SignFooter from '@/components/common/Footer/SignFooter';
+import { RoutePath } from '@/pages/routes';
+
+const Footer = () => {
+  const { pathname } = useLocation();
+
+  const isSignFooter = SIGN_FOOTER_URL.includes(pathname);
+  const isDefaultFooter = DEFAULT_FOOTER_URL.includes(pathname);
+
+  if (isSignFooter) {
+    return <SignFooter />;
+  }
+
+  if (isDefaultFooter) {
+    return <DefaultFooter />;
+  }
+
+  return null;
+};
+
+export default Footer;
+
+const SIGN_FOOTER_URL: RoutePath[] = ['/signin', '/signup'];
+
+const DEFAULT_FOOTER_URL: RoutePath[] = ['/', '/category'];

--- a/src/components/common/Footer/SignFooter.styles.tsx
+++ b/src/components/common/Footer/SignFooter.styles.tsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom';
+import styled from '@emotion/styled';
+
+import { theme } from '@/styles/theme';
+
+export const LinkBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  > p {
+    color: white;
+    ${theme.font.body2}
+  }
+`;
+
+export const LinkText = styled(Link)`
+  color: ${theme.color.brand};
+  ${theme.font.body1}
+`;

--- a/src/components/common/Footer/SignFooter.tsx
+++ b/src/components/common/Footer/SignFooter.tsx
@@ -1,0 +1,27 @@
+import { useLocation } from 'react-router-dom';
+
+import { FooterContainer } from '@/components/common/Footer/DefaultFooter.styles';
+import { LinkBox, LinkText } from '@/components/common/Footer/SignFooter.styles';
+
+const SignFooter = () => {
+  const { pathname } = useLocation();
+
+  const text = pathname === '/signin' ? '아직 회원이 아니신가요?' : '아이디가 있으신가요?';
+
+  const link =
+    pathname === '/signin' ? (
+      <LinkText to="/signup">회원가입 하러 가기</LinkText>
+    ) : (
+      <LinkText to="/signin">로그인 하러 가기</LinkText>
+    );
+  return (
+    <FooterContainer>
+      <LinkBox>
+        <p>{text}</p>
+        {link}
+      </LinkBox>
+    </FooterContainer>
+  );
+};
+
+export default SignFooter;

--- a/src/pages/DefaultLayout/DefaultLayout.styles.tsx
+++ b/src/pages/DefaultLayout/DefaultLayout.styles.tsx
@@ -7,6 +7,7 @@ export const DefaultLayoutWrapper = styled.main<{ onlyDesktop: boolean }>`
   max-width: 420px;
   margin: 0 auto;
   background-color: ${theme.color.backgroundColor};
+  position: relative;
 
   // 구현하다가 막히면 이 부분 수정해도됨
   height: 100vh;

--- a/src/pages/DefaultLayout/DefaultLayout.tsx
+++ b/src/pages/DefaultLayout/DefaultLayout.tsx
@@ -1,5 +1,6 @@
 import { Outlet, useLocation } from 'react-router-dom';
 
+import Footer from '@/components/common/Footer/Footer.tsx';
 import { Header } from '@/components/common/Header/Header.tsx';
 import { RoutePath } from '@/pages/routes.tsx';
 import * as S from './DefaultLayout.styles.tsx';
@@ -18,6 +19,7 @@ export function DefaultLayout() {
     <S.DefaultLayoutWrapper onlyDesktop={onlyDesktop}>
       <Header />
       <Outlet />
+      <Footer />
     </S.DefaultLayoutWrapper>
   );
 }


### PR DESCRIPTION
close #25 

## 💡 개요
![2023-09-02 21;40;31](https://github.com/supercoding-commerce/FE/assets/112530541/6f10ecd8-efb1-4ebe-83b5-055ea508ee40)


## 📝 작업 내용
- footer UI를 두 종류로 나눠서 작업(default, sign)
- 레이아웃 컴포넌트에 footer를 추가 ( 경로에 따라 보여지는 footer가 달라짐 )

## ‼️ 주의 사항
- sns 아이콘 추가되면 sns 부분 수정 예정
- 로고 추가되면 수정 예정

## 🔗 참고자료
