### PR TITLE
fix: 상대방이 보낸 채팅 실시간 반영 안되는 이슈 완료

### DIFF
--- a/src/components/Detail/detailInformation/InformationBox.tsx
+++ b/src/components/Detail/detailInformation/InformationBox.tsx
@@ -21,9 +21,9 @@ const InformationBox = ({ productImage }: InformationProps) => {
   return (
     <S.DetailInformation>
       <div className={containerClassName}>
-        {productImage?.map((item) => {
+        {productImage?.map((item, idx) => {
           return (
-            <div className="information_box">
+            <div className="information_box" key={idx}>
               <img src={item} alt="상품정보" />
             </div>
           );

--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -5,19 +5,52 @@ import ChatDetail from '@/components/chat/ChatDetail';
 import ChatList from '@/components/chat/ChatList';
 import * as S from './Chat.styles';
 
-const Chat = () => {
-  const seller = { sellerId: 3, shopName: '상점3' };
-  /** TODO: 로그인할때 유저정보에서 받아올 것. 리코일 쓰나? */
-  const user = { userId: 12, userName: 'kristengreen' };
-  /** TODO: 디테일 페이지에서 props로 받아올 것 */
-  const product = { productId: 5, productName: 'what' };
-  const isSeller = true;
-  const role = isSeller ? 'seller' : 'user';
-  const roomId = createCustomRoomId(seller.sellerId, product.productId, user.userId);
+type ChatProps = {
+  sellerId: number;
+  sellerName: string;
+  userId: number;
+  userName: string;
+  productId: number;
+  productName: string;
+  isUser: boolean;
+};
 
-  const [customRoomId, setCustomRoomId] = useState<string>(roomId);
+export type UserInfo = {
+  userId: number;
+  userName: string;
+};
+
+export type ProductInfo = {
+  productId: number;
+  productName: string;
+};
+
+export type SellerInfo = {
+  sellerId: number;
+  shopName: string;
+};
+
+const Chat = ({
+  sellerId,
+  sellerName,
+  userId,
+  userName,
+  productId,
+  productName,
+  isUser,
+}: ChatProps) => {
+  const seller: SellerInfo = { sellerId: sellerId, shopName: sellerName };
+  const product: ProductInfo = { productId: productId, productName: productName };
+  const [user, setUser] = useState<UserInfo>({ userId: userId, userName: userName });
   const [isCustomRoomId, setIsCustomRoomId] = useState<boolean>(true);
+
+  const isSeller = isUser;
+  const role = isSeller ? 'seller' : 'user';
+
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const roomId = createCustomRoomId(seller.sellerId, product.productId, user.userId);
+  const [customRoomId, setCustomRoomId] = useState<string>(roomId);
 
   /** createCustomRoomId() : 소켓 방 열때 필요한 roomId 조합생성 */
   function createCustomRoomId(sellerId: number, productId: number, userId: number) {
@@ -39,10 +72,13 @@ const Chat = () => {
   /** clickListBox() : 채팅list에서 해당 채팅방으로 들어가기 위해
    * 1. isCustomRoomId를 false,
    * 2. ChatBody.tsx에서 custumroomId를 받아와서 ChatList.tsx로 넘겨줌.
+   * 3. seller일때 현재 디테일에서 넘어오는 userId, userName값은 판매자의 정보여서 ChatList.tsx에서
+        문의한 구매자의 userId값, userName값을 가져옴.
    */
-  const clickListBox = (customRoomId: string) => {
+  const clickListBox = (customRoomId: string, userId: number, userName: string) => {
     setIsCustomRoomId((prev) => !prev);
     setCustomRoomId(customRoomId);
+    setUser({ ...user, userId, userName });
   };
 
   const handleOpen = () => {

--- a/src/components/chat/ChatDetail.tsx
+++ b/src/components/chat/ChatDetail.tsx
@@ -48,9 +48,6 @@ const ChatDetail = ({
     [seller.shopName]: false,
   });
 
-  console.log(userStatus);
-  console.log('방금한 채팅 반영 안됨?', msg);
-
   const loadPrevChat: () => Promise<void> = async () => {
     await client
       .get(`/v1/api/chat/detail/${customRoomId}`)
@@ -88,16 +85,16 @@ const ChatDetail = ({
 
   /** handleLeave() : 유저가 채팅방을 떠날 때 */
   const handleLeave = () => {
-    stompClient.publish({
-      destination: `/topic/${seller.sellerId}/${product.productId}/${user.userId}`,
-      body: JSON.stringify({
-        shopName: seller.shopName,
-        userName: user.userName,
-        sender: role === 'user' ? user.userName : seller.shopName,
-        type: 'LEAVE',
-      }),
-    });
-    console.log('떠나나?');
+    if (!userStatus[user.userName] && !userStatus[seller.shopName])
+      stompClient.publish({
+        destination: `/topic/${seller.sellerId}/${product.productId}/${user.userId}`,
+        body: JSON.stringify({
+          shopName: seller.shopName,
+          userName: user.userName,
+          sender: role === 'user' ? user.userName : seller.shopName,
+          type: 'LEAVE',
+        }),
+      });
   };
 
   /** handleTerminate() : 유저, 셀러 전부 떠났을때 */
@@ -111,7 +108,6 @@ const ChatDetail = ({
           type: 'TERMINATE',
         }),
       });
-      console.log('끊겼나?');
     } else return;
   };
 
@@ -142,7 +138,6 @@ const ChatDetail = ({
         (body) => {
           // message -> 백엔드랑 논의 완료 (백엔드에서 어떻게 보내주는지)
           const message = JSON.parse(body.body);
-          console.log('message', message);
           if (message.type === 'JOIN') {
             console.log('연결되었습니다.');
           } else if (message.type === 'LEAVE') {

--- a/src/components/chat/ChatList.tsx
+++ b/src/components/chat/ChatList.tsx
@@ -22,7 +22,7 @@ export type list = {
 };
 
 type chatProps = {
-  clickListBox: (customRoomId: string) => void;
+  clickListBox: (customRoomId: string, userId: number, userName: string) => void;
   seller: {
     sellerId: number;
     shopName: string;
@@ -35,20 +35,15 @@ type chatProps = {
 };
 
 const ChatList = ({ clickListBox, seller, isSeller, product }: chatProps) => {
-  /** TODO: 디테일 페이지에서 props로 받아올 것 */
   const [list, setList] = useState<list[]>([]);
 
   const [shopImg, setShopImg] = useState<string>('');
-
-  console.log(seller.sellerId);
-  console.log('isSeller', seller.sellerId);
 
   const loadUserChatList: () => Promise<void> = async () => {
     const sellerId = seller.sellerId;
     await client
       .get(`/v1/api/chat/user/${sellerId}`)
       .then((res) => {
-        console.log(res.data);
         const data = res.data.chatList;
         const img = res.data.shopImage;
         setList([...data]);
@@ -65,7 +60,6 @@ const ChatList = ({ clickListBox, seller, isSeller, product }: chatProps) => {
     await client
       .get(`/v1/api/chat/seller/${sellerId}/${productId}`)
       .then((res) => {
-        console.log(res.data);
         const data = res.data.chatList;
         const img = res.data.shopImage;
         setList([...data]);
@@ -80,9 +74,6 @@ const ChatList = ({ clickListBox, seller, isSeller, product }: chatProps) => {
     if (!isSeller) loadUserChatList();
     else loadSellerChatList();
   }, [isSeller]);
-
-  console.log('chatList', list);
-  console.log('shopImg', shopImg);
 
   return (
     <div>

--- a/src/components/chat/chatDetail/ChatDetailHeader.tsx
+++ b/src/components/chat/chatDetail/ChatDetailHeader.tsx
@@ -3,12 +3,19 @@ import * as S from '../Chat.styles';
 
 type headerProps = {
   handleLeave: () => void;
+  handleTerminate: () => void;
   clickPrevButton: () => void;
   handleOpen: () => void;
   shopName: string;
 };
 
-const ChatDetailHeader = ({ handleLeave, clickPrevButton, handleOpen, shopName }: headerProps) => {
+const ChatDetailHeader = ({
+  handleLeave,
+  handleTerminate,
+  clickPrevButton,
+  handleOpen,
+  shopName,
+}: headerProps) => {
   return (
     <S.ChatDetailHeader>
       <div className="arrow_btn_wrapper">
@@ -19,6 +26,7 @@ const ChatDetailHeader = ({ handleLeave, clickPrevButton, handleOpen, shopName }
           size={30}
           onClick={() => {
             handleLeave();
+            handleTerminate();
             clickPrevButton();
           }}
         />
@@ -34,6 +42,7 @@ const ChatDetailHeader = ({ handleLeave, clickPrevButton, handleOpen, shopName }
           size={25}
           onClick={() => {
             handleLeave();
+            handleTerminate();
             handleOpen();
           }}
         />

--- a/src/components/chat/chatList/ChatBody.tsx
+++ b/src/components/chat/chatList/ChatBody.tsx
@@ -4,17 +4,15 @@ import * as S from '../Chat.styles';
 
 type ChatBodyProps = {
   chatList: list[];
-  clickListBox: (customRoomId: string) => void;
+  clickListBox: (customRoomId: string, userId: number, userName: string) => void;
 };
 
 const ChatBody = ({ chatList, clickListBox }: ChatBodyProps) => {
-  console.log('chatList1', chatList);
-
   return (
     <S.ChatBody>
       {chatList?.map((item, idx) => {
         return (
-          <div onClick={() => clickListBox(item.customRoomId)}>
+          <div onClick={() => clickListBox(item.customRoomId, item.userId, item.userName)}>
             <ChatBox
               key={idx}
               lastChat={item.lastChat.content}

--- a/src/pages/DetailPage/DetailPage.tsx
+++ b/src/pages/DetailPage/DetailPage.tsx
@@ -13,6 +13,10 @@ import ProductOption from '@/components/DetailHeader/ProductOption';
 import { theme } from '@/styles/theme';
 
 export type DetailProduct = {
+  seller: boolean;
+  sellerId: number;
+  enteredUserId: number;
+  enteredUserName: string;
   productId: number;
   thumbnailUrl: string;
   shopName: string;
@@ -87,7 +91,15 @@ const DetailPage = () => {
 
   return (
     <>
-      <Chat />
+      <Chat
+        sellerId={product.sellerId}
+        sellerName={product.shopName}
+        userId={product.enteredUserId}
+        userName={product.enteredUserName}
+        productId={product.productId}
+        productName={product.name}
+        isUser={product.seller}
+      />
       <DetailPageContainer>
         <DetailHeader product={product} />
         <ProductOption


### PR DESCRIPTION
close #134 

## 💡 개요
1. 서로에게 보낸 채팅 실시간 반영 안됨
2. 두명 다 떠났을때 소켓 끊는 메세지 제대로 반영 안됨
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 📝 작업 내용

### 1. 서로에게 보낸 채팅 실시간 반영 안됨 : 

https://github.com/supercoding-commerce/FE/assets/100771469/8dc1830b-4bea-44df-8265-d4977f4bbb8c

    - 테스트해보니 서버에서 상대방 행동에 대한 신호를 못받았습니다.
    - 그 이유는 서버에서 주는 product 데이터 내용 중 userId를 구매자의 Id로 혼동했었습니다.
    - 그래서 셀러때만 채팅리스트가 먼저 보이기 때문에 거기에서 문의한 구매자의 userId로 다시 user 객체 내용을 업데이트 했습니다.


###  2. 두명 다 떠났을때 소켓 끊는 메세지 제대로 반영 안됨

https://github.com/supercoding-commerce/FE/assets/100771469/c4aa8e71-c655-4de7-b030-6422436e644d

    - 처음에 판매자나 구매자가 채팅방 나갈때 leave 메세지를 publish해서 각각 true로 변환해서 둘다
    true가 되어야만 소켓 연결을 끊는 터미네이터 메세지가 publish되도록 했었습니다.
    - 하지만 한명이 떠났을땐 leave 메세지 신호가 subscribe로 왔지만 나머지 한명이 방을 떠날때 채팅창을 끄는것이기 때문에
    true로 변하지 않았고 leave 메세지도 받지 못했습니다.
    - 그래서 한명이 채팅방을 떠나서 true로 변경되었을때 나머지 한명이 채팅창을 끄거나 채팅리스트로 이동을 하면
    바로  터미네이터 메세지가 publish 되게끔 조건을 변경했습니다.
<!-- 작업한 UI 있으면 UI 첨부 -->
<!-- 작업 내용 -->

## ‼️ 주의 사항

<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->


<!-- 작업한 UI 있으면 UI 첨부 -->
<!-- 작업 내용 -->

## ‼️ 주의 사항

<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->
