### PR TITLE
fix:#154 채팅 판매자 랜덤으로 실시간반영 이슈

### DIFF
--- a/src/components/chat/ChatDetail.tsx
+++ b/src/components/chat/ChatDetail.tsx
@@ -141,11 +141,12 @@ const ChatDetail = ({
           if (message.type === 'JOIN') {
             console.log('연결되었습니다.');
           } else if (message.type === 'LEAVE') {
+            handleDisConnect();
             const leave = message.sender;
             setLeaveUser(leave);
             setUserStatus((prevUserStatus) => ({
               ...prevUserStatus,
-              [message.sender]: true, // 해당 유저의 상태를 입장으로 설정
+              [message.sender]: true, // 해당 유저의 상태를 퇴장으로 설정
             }));
           } else if (message.type === 'TERMINATE') {
             handleDisConnect();
@@ -181,7 +182,7 @@ const ChatDetail = ({
     // return () => {
     //   handleDisConnect();
     // };
-  }, []);
+  }, [userStatus]);
 
   return (
     <>

--- a/src/components/chat/chatList/ChatBody.tsx
+++ b/src/components/chat/chatList/ChatBody.tsx
@@ -12,11 +12,13 @@ const ChatBody = ({ chatList, clickListBox }: ChatBodyProps) => {
     <S.ChatBody>
       {chatList?.map((item, idx) => {
         return (
-          <div onClick={() => clickListBox(item.customRoomId, item.userId, item.userName)}>
+          <div
+            onClick={() => clickListBox(item.customRoomId, item.userId, item.userName)}
+            key={idx}
+          >
             <ChatBox
-              key={idx}
               lastChat={item.lastChat.content}
-              sender={item.lastChat.sender}
+              sender={item?.lastChat.sender}
               productName={item.productName}
               image={item.imageUrl}
             />


### PR DESCRIPTION
close #154 
## 💡 개요
채팅 판매자 랜덤으로 실시간반영 되었던 이슈 입니다.
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 📝 작업 내용
1. 판매자 뿐만 아니라 구매자도 채팅방을 떠나서 leave 표시가 떴을때 상대방이 아직 채팅방에 join이라면
본인이 다시 해당 채팅방에 들어가도 다시 join이 되지않고 leave상태 그대로 있어서 실시간 반영이 안되었던 것으로 확인했습니다.
2.  그래서 한명이 떠났을때도 소켓을 끊기게 만들었고 해당 useEffect의 의존성 배열에 둘중 한명이 나갔는지 체크하는 userStatus
를 넣어서 join메세지가 뜨게끔 수정했습니다.
<!-- 작업한 UI 있으면 UI 첨부 -->
<!-- 작업 내용 -->

## ‼️ 주의 사항
다만 한명이 떠났을때 소켓을 끊었기때문에 남아있는사람도 그전 소켓 클라이언트 객체가 아닌
새로운 서버랑 연결할 클라이언트 객체로 갈아끼워지는것을 확인했습니다.
일단 지금 돌아가는것에는 문제가 없어서 마이페이지 쿠폰만 하고 다시 리팩토링 예정입니다.. 

<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->
