### PR TITLE
fix : 닉네임 중복확인 api url 변경

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -48,9 +48,9 @@ export const checkEmail = async (payload: string) => {
 };
 
 export const checkNickName = async (payload: string) => {
-  const response = await client.get(`${USER_URL}/checkNickName`, {
+  const response = await client.get(`${USER_URL}/checkNickname`, {
     params: {
-      nickName: payload,
+      nickname: payload,
     },
   });
   return response;


### PR DESCRIPTION
close #191 

## 💡 개요
- 회원 가입 시 닉네임 중복확인 api 호출을 했을 때 404 에러가 뜸

## 📝 작업 내용
- 스웨거 확인해서 기존 요청 url이 변경 된 점을 확인
- 변경된 url 반영 후 테스트 완료

## ‼️ 주의 사항

<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->
