### PR TITLE
refactor:chat 관련 분리 및 수정

### DIFF
--- a/src/components/chat/ChatDetail.tsx
+++ b/src/components/chat/ChatDetail.tsx
@@ -7,7 +7,7 @@ import ChatDetailBody from '@/components/chat/chatDetail/ChatDetailBody';
 import ChatDetailHeader from '@/components/chat/chatDetail/ChatDetailHeader';
 import ChatSend from '@/components/chat/chatDetail/ChatSend';
 import { useChat } from '@/hooks/useChat';
-import { Message } from '@/models/\bchat';
+import { Message } from '@/models/chat';
 
 export type ChatUserProps = {
   customRoomId: string | null;

--- a/src/components/chat/ChatDetail.tsx
+++ b/src/components/chat/ChatDetail.tsx
@@ -6,13 +6,10 @@ import { ProductInfo, SellerInfo, UserInfo } from '@/components/chat/Chat';
 import ChatDetailBody from '@/components/chat/chatDetail/ChatDetailBody';
 import ChatDetailHeader from '@/components/chat/chatDetail/ChatDetailHeader';
 import ChatSend from '@/components/chat/chatDetail/ChatSend';
+import { useChat } from '@/hooks/useChat';
+import { Message } from '@/models/\bchat';
 
-export type Msg = {
-  sender: string;
-  content: string;
-};
-
-type ChatUserProps = {
+export type ChatUserProps = {
   customRoomId: string | null;
   role: string;
   seller: SellerInfo;
@@ -38,27 +35,29 @@ const ChatDetail = ({
       brokerURL: `${import.meta.env.VITE_API_CHAT_URL}/chat`,
     }),
   );
-  // 지금부터 보낼 메세지 담기
-  const [msg, setMsg] = useState<Msg[]>([]);
+
   // 이전의 메세지 기록 담기
-  const [prevMsg, setPrevMsg] = useState<Msg[]>([]);
-  // 판매자, 유저 전부 채팅방 떠났는지 확인ㄹ
-  const [userStatus, setUserStatus] = useState({
-    user: false,
-    seller: false,
+  const [prevMessage, setPrevMessage] = useState<Message[]>([]);
+
+  const message = useChat({
+    customRoomId,
+    seller,
+    user,
+    role,
+    product,
+    stompClient,
   });
 
-  console.log('detailMsg', msg);
-  console.log('userStatus', userStatus);
+  console.log('GYU MSG', message);
 
   const loadPrevChat: () => Promise<void> = async () => {
     await client
       .get(`/v1/api/chat/detail/${customRoomId}`)
       .then((res) => {
         console.log(res);
-        const prev = res.data.chats;
-        const msgArray: Msg[] = Object.values(prev);
-        setPrevMsg([...msgArray]);
+        const data = res.data.chats;
+        const prevMessage: Message[] = Object.values(data);
+        setPrevMessage([...prevMessage]);
       })
       .catch((err) => {
         console.log(err);
@@ -86,160 +85,18 @@ const ChatDetail = ({
     }
   };
 
-  /** handleLeave() : 유저가 채팅방을 떠날 때 */
-  const handleLeave = () => {
-    if (!userStatus.user && !userStatus.seller) {
-      stompClient.publish({
-        destination: `/topic/${seller.sellerId}/${product.productId}/${user.userId}`,
-        body: JSON.stringify({
-          shopName: seller.shopName,
-          userName: user.userName,
-          sender: role === 'user' ? user.userName : seller.shopName,
-          type: 'LEAVE',
-        }),
-      });
-    }
-  };
-
-  /** handleTerminate() : 유저, 셀러 전부 떠났을때 */
-  const handleTerminate = () => {
-    if (userStatus.user && userStatus.seller) {
-      stompClient.publish({
-        destination: `/topic/${seller.sellerId}/${product.productId}/${user.userId}`,
-        body: JSON.stringify({
-          shopName: seller.shopName,
-          userName: user.userName,
-          type: 'TERMINATE',
-        }),
-      });
-    } else return;
-  };
-
-  /** handleDisConnect() : 소켓 객체 비활성화(끊기) */
-  const handleDisConnect = () => {
-    if (stompClient.connected) {
-      // 전역에 만들어진 클라이언트 소켓 객체를 연결 종료하고 삭제.
-      stompClient.deactivate();
-      console.log('연결이 끊겼습니다.');
-    }
-  };
-
-  // 처음 들어왔을때 joinMessage를 보내서 stompClient연결
-  useEffect(() => {
-    const joinMessage = {
-      customRoomId: customRoomId,
-      shopName: seller.shopName,
-      userName: user.userName,
-      role: role,
-      type: 'JOIN',
-    };
-
-    // 연결이 된 경우 콜백함수 호출(어떻게 동작할지 정의)
-    stompClient.onConnect = () => {
-      // 구독하기(메세지 받음)
-      stompClient.subscribe(
-        `/topic/${seller.sellerId}/${product.productId}/${user.userId}`,
-        (body) => {
-          // message -> 백엔드랑 논의 완료 (백엔드에서 어떻게 보내주는지)
-          const message = JSON.parse(body.body);
-          console.log(message);
-          if (message.type === 'JOIN') {
-            const join = message.role === 'user' ? message.userName : message.shopName;
-            const msgContent = `${join}님이 채팅을 시작하셨습니다.`;
-            const msgSender = 'server';
-            const msg1 = { content: msgContent, sender: msgSender };
-            setMsg((prev) => [...prev, msg1]);
-            {
-              role === 'user'
-                ? setUserStatus((prevUserStatus) => ({
-                    ...prevUserStatus,
-                    user: false, // 해당 유저의 상태를 퇴장으로 설정
-                  }))
-                : setUserStatus((prevUserStatus) => ({
-                    ...prevUserStatus,
-                    seller: false, // 해당 유저의 상태를 퇴장으로 설정
-                  }));
-            }
-          } else if (message.type === 'LEAVE') {
-            // handleDisConnect();
-            {
-              message.sender === user.userName
-                ? setUserStatus((prevUserStatus) => ({
-                    ...prevUserStatus,
-                    user: true, // 해당 유저의 상태를 퇴장으로 설정
-                  }))
-                : setUserStatus((prevUserStatus) => ({
-                    ...prevUserStatus,
-                    seller: true, // 해당 유저의 상태를 퇴장으로 설정
-                  }));
-            }
-            // setUserStatus((prevUserStatus) => ({
-            //   ...prevUserStatus,
-            //   [message.sender]: true, // 해당 유저의 상태를 퇴장으로 설정
-            // }));
-
-            const leave = message.sender;
-            const msgContent = `${leave}님이 채팅을 종료하셨습니다.`;
-            const msgSender = 'server';
-            const msg1 = { content: msgContent, sender: msgSender };
-            setMsg((prev) => [...prev, msg1]);
-          } else if (message.type === 'TERMINATE') {
-            handleDisConnect();
-            setUserStatus({
-              user: false,
-              seller: false,
-            });
-          } else {
-            console.log('들어오나?');
-            const msgContent = message.content;
-            const msgSender = message.sender;
-            const msg1 = { content: msgContent, sender: msgSender }; // currentMessage
-            // console.log('msg1', msg1, msg);
-
-            setMsg((prev) => [...prev, msg1]);
-            console.log('setMsg 까지 호출', setMsg);
-          }
-        },
-      );
-
-      // 소켓 통신 호출 - 목적지 url로 메시지 보내기 (ex)JOIN 하기, 방떠나기!
-      stompClient.publish({
-        destination: `/app/chat.addUser/${seller.sellerId}/${product.productId}/${user.userId}`,
-        body: JSON.stringify(joinMessage),
-      });
-    };
-
-    // 에러가 나오는 경우 어떻게 동작할지 정의 - 콜백함수 호출
-    stompClient.onStompError = (frame) => {
-      // TODO: 어떻게 에러를 유저에게 안내해줄지 고민
-      console.log('연결 실패', frame);
-    };
-
-    // 전역에 만들어진 클라이언트 소켓 객체 활성화(연결)
-    stompClient.activate();
-
-    // return () => {
-    //   handleDisConnect();
-    // };
-  }, []);
-
-  console.log('gyu msg', msg);
-
   return (
     <>
       <ChatDetailHeader
-        handleLeave={handleLeave}
-        handleTerminate={handleTerminate}
         shopName={seller.shopName}
         clickPrevButton={clickPrevButton}
         handleOpen={handleOpen}
       />
       <ChatDetailBody
-        prevMsg={prevMsg}
-        msg={msg}
+        prevMessage={prevMessage}
+        message={message}
         role={role}
         nickName={role === 'user' ? user.userName : seller.shopName}
-        // leaveUser={leaveUser}
         shopName={seller.shopName}
         shopImageUrl={shopImageUrl}
       />

--- a/src/components/chat/chatDetail/ChatDetailBody.tsx
+++ b/src/components/chat/chatDetail/ChatDetailBody.tsx
@@ -1,38 +1,43 @@
 import { useEffect, useRef } from 'react';
 
-import { Msg } from '@/components/chat/ChatDetail';
 import ChatDetailIntro from '@/components/chat/chatDetail/ChatDetailIntro';
-// import ChatLeaveBox from '@/components/chat/chatDetail/ChatLeaveBox';
 import ChatLeftBox from '@/components/chat/chatDetail/ChatLeftBox';
 import ChatRightBox from '@/components/chat/chatDetail/ChatRightBox';
+import { Message } from '@/models/chat';
 import * as S from '../Chat.styles';
 
 type MsgProps = {
-  msg: Msg[];
-  prevMsg: Msg[];
+  message: Message[];
+  prevMessage: Message[];
   nickName: string;
-  // leaveUser: string;
   shopName: string;
   shopImageUrl: string;
   role: string;
 };
 
-const ChatDetailBody = ({ prevMsg, msg, nickName, shopName, shopImageUrl, role }: MsgProps) => {
+const ChatDetailBody = ({
+  prevMessage,
+  message,
+  nickName,
+  shopName,
+  shopImageUrl,
+  role,
+}: MsgProps) => {
   const RefViewControll = useRef<HTMLDivElement>(null);
 
   //가장 최근 채팅 보여주기
   useEffect(() => {
-    if (RefViewControll.current && prevMsg.length > 0) {
+    if (RefViewControll.current && prevMessage.length > 0) {
       RefViewControll.current.scrollTop = RefViewControll.current.scrollHeight;
     }
-  }, [msg, prevMsg]);
+  }, [message, prevMessage]);
 
   // console.log(nickName, msg);
 
   return (
     <S.ChatDetailBody ref={RefViewControll}>
       <ChatDetailIntro shopName={shopName} shopImageUrl={shopImageUrl} />
-      {prevMsg.map((item, idx) => {
+      {prevMessage.map((item, idx) => {
         return nickName === item.sender ? (
           <ChatRightBox key={idx} content={item.content} />
         ) : (
@@ -45,7 +50,7 @@ const ChatDetailBody = ({ prevMsg, msg, nickName, shopName, shopImageUrl, role }
           />
         );
       })}
-      {msg.map((item, idx) => {
+      {message.map((item, idx) => {
         return nickName === item.sender ? (
           <ChatRightBox key={idx} content={item.content} />
         ) : (

--- a/src/components/chat/chatDetail/ChatDetailHeader.tsx
+++ b/src/components/chat/chatDetail/ChatDetailHeader.tsx
@@ -2,20 +2,12 @@ import Icon from '@/components/common/Icon';
 import * as S from '../Chat.styles';
 
 type headerProps = {
-  handleLeave: () => void;
-  handleTerminate: () => void;
   clickPrevButton: () => void;
   handleOpen: () => void;
   shopName: string;
 };
 
-const ChatDetailHeader = ({
-  handleLeave,
-  handleTerminate,
-  clickPrevButton,
-  handleOpen,
-  shopName,
-}: headerProps) => {
+const ChatDetailHeader = ({ clickPrevButton, handleOpen, shopName }: headerProps) => {
   return (
     <S.ChatDetailHeader>
       <div className="arrow_btn_wrapper">
@@ -25,8 +17,6 @@ const ChatDetailHeader = ({
           cursor={'pointer'}
           size={30}
           onClick={() => {
-            handleLeave();
-            handleTerminate();
             clickPrevButton();
           }}
         />
@@ -41,8 +31,6 @@ const ChatDetailHeader = ({
           cursor={'pointer'}
           size={25}
           onClick={() => {
-            handleLeave();
-            handleTerminate();
             handleOpen();
           }}
         />

--- a/src/components/chat/chatDetail/ChatLeaveBox.tsx
+++ b/src/components/chat/chatDetail/ChatLeaveBox.tsx
@@ -1,10 +1,9 @@
+import { Message } from '@/models/chat';
 import * as S from '../Chat.styles';
 
-type MsgProps = {
-  content?: string;
-};
+type MessageProps = Pick<Message, 'content'>;
 
-const ChatLeaveBox = ({ content }: MsgProps) => {
+const ChatLeaveBox = ({ content }: MessageProps) => {
   console.log('ChatLeaveBox', content);
 
   return (

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Client } from '@stomp/stompjs';
 
 import { ChatUserProps } from '@/components/chat/ChatDetail';
-import { Message } from '@/models/\bchat';
+import { Message } from '@/models/chat';
 
 type useChatProps = Pick<
   ChatUserProps, //

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+import { Client } from '@stomp/stompjs';
+
+import { ChatUserProps } from '@/components/chat/ChatDetail';
+import { Message } from '@/models/\bchat';
+
+type useChatProps = Pick<
+  ChatUserProps, //
+  'customRoomId' | 'seller' | 'user' | 'role' | 'product'
+> & { stompClient: Client };
+
+export function useChat({ customRoomId, seller, user, role, product, stompClient }: useChatProps) {
+  const [isConnected, setIsConnected] = useState(false);
+  const [receivedMessage, setReceivedMessage] = useState<ReceivedMessage | null>(null);
+
+  const [message, setMessage] = useState<Message[]>([]);
+
+  const handleDisConnect = () => {
+    if (stompClient.connected) {
+      // 전역에 만들어진 클라이언트 소켓 객체를 연결 종료하고 삭제.
+      stompClient.deactivate();
+      console.log('연결이 끊겼습니다.');
+    }
+  };
+
+  // 처음 들어왔을때 socket 이벤트 정의 및 JOIN 호출
+  useEffect(() => {
+    const joinMessage = {
+      customRoomId: customRoomId,
+      shopName: seller.shopName,
+      userName: user.userName,
+      role: role,
+      type: 'JOIN',
+    };
+
+    // function userJoin() {
+    //   stompClient.publish({
+    //     destination: `/app/chat.addUser/${seller.sellerId}/${product.productId}/${user.userId}`,
+    //     body: JSON.stringify(joinMessage),
+    //   });
+    // }
+
+    stompClient.onConnect = () => {
+      if (isConnected) return;
+
+      // clean code early return -> 일반적이지 않은 경우를 먼저 반환?
+      // 예외조건 먼저 처리
+      // if(!A)  return;
+      // if(!B) return;
+      // if(C) return;
+
+      // 정상적인 로직 수행
+      // ...
+
+      // 이미 연결되어 있지 않을 경우에만 JOIN 메시지 전송
+      // if (!isConnected) {
+      stompClient.subscribe(
+        `/topic/${seller.sellerId}/${product.productId}/${user.userId}`,
+        (body) => {
+          const message = JSON.parse(body.body);
+          setReceivedMessage(message);
+          console.log(message);
+        },
+      );
+
+      // userJoin();
+      stompClient.publish({
+        destination: `/app/chat.addUser/${seller.sellerId}/${product.productId}/${user.userId}`,
+        body: JSON.stringify(joinMessage),
+      });
+
+      // 연결 상태를 true로 설정
+      setIsConnected(true);
+      // }
+    };
+
+    stompClient.onStompError = (frame) => {
+      console.log('연결 실패', frame);
+      // 연결이 실패하면 연결 상태를 false로 설정
+      setIsConnected(false);
+    };
+
+    stompClient.activate();
+
+    return () => {
+      handleDisConnect();
+      // 컴포넌트가 언마운트 될 때 연결 상태를 false로 설정
+      setIsConnected(false);
+    };
+  }, []);
+
+  // 소켓에서 이벤트 수신에 따른 로직 처리
+  useEffect(() => {
+    console.log('GYU MESSAGE receivedMessage', receivedMessage);
+    // Early return
+    if (!receivedMessage) return;
+
+    let join;
+    let messageContent;
+    let messageSender;
+    let message: Message;
+    let leaver;
+
+    switch (receivedMessage.type) {
+      case 'JOIN':
+        join =
+          receivedMessage.role === 'user' ? receivedMessage.userName : receivedMessage.shopName;
+        messageContent = `${join}님이 채팅을 시작하셨습니다.`;
+        messageSender = 'server';
+        message = { content: messageContent, sender: messageSender };
+        setMessage((prev) => [...prev, message]);
+        break;
+
+      case 'LEAVE':
+        leaver = receivedMessage.userName || receivedMessage.shopName;
+        messageContent = `${leaver}님이 채팅을 종료하셨습니다.`;
+        messageSender = 'server';
+        message = { content: messageContent, sender: messageSender };
+        setMessage((prev) => [...prev, message]);
+        break;
+
+      case 'TERMINATE':
+        handleDisConnect();
+        break;
+
+      case 'CHAT':
+        messageContent = receivedMessage.content;
+        messageSender = receivedMessage.sender;
+        if (messageContent && messageSender) {
+          const message = { content: messageContent, sender: messageSender };
+          setMessage((prev) => [...prev, message]);
+        }
+        break;
+
+      default:
+        // sentry - 에러 로깅!
+        console.error('존재하지 않는 이벤트 입니다.');
+    }
+  }, [receivedMessage]);
+
+  return message;
+}
+
+type ReceivedMessage = {
+  type: string;
+  shopName: string;
+  userName: string;
+  role: string;
+  customRoomId: string;
+  content?: string;
+  sender?: string;
+};

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -1,0 +1,19 @@
+export type Message = {
+  sender: string;
+  content: string;
+};
+
+export type UserInfo = {
+  userId: number;
+  userName: string;
+};
+
+export type ProductInfo = {
+  productId: number;
+  productName: string;
+};
+
+export type SellerInfo = {
+  sellerId: number;
+  shopName: string;
+};

--- a/src/recoil/productListState.ts
+++ b/src/recoil/productListState.ts
@@ -1,9 +1,0 @@
-// ** 통신시 구현 전역데이터 관리 로직 **
-// import { atom } from 'recoil';
-
-// import { Product } from '../components/MainPage/ListItemComponent/AllProductList';
-
-// export const productListState = atom<Product[]>({
-//   key: 'productListState',
-//   default: [],
-// });


### PR DESCRIPTION
close #203

## 💡 개요
chat 관련 분리 및 수정

<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 📝 작업 내용
1. undefined 님이 채팅을 종료하셨습니다. 수정
2. 관심사 분리를 위한 커스텀 훅을 이용해 서비스 로직과 ui 관련 로직 분리
3. receivedMessage의 type에 따른 처리를 가독성을 위해 if문 -> switch문으로 수정
4. 핵심 chat type 분리와 핵심 type 중 한부분을 이용할 수 있도록 pick을 사용
5. 가독성을 높이기 위해 줄여쓴 변수 이름 수정
6. Early return으로 예외적인 분기처리 먼저 하도록 수정
7. 안쓰는 props 등 삭제
<!-- 작업한 UI 있으면 UI 첨부 -->
<!-- 작업 내용 -->

## ‼️ 주의 사항
type CHAT은 백엔드에서 추가해주셔야 될 부분이 있어서
지금은 채팅 잠시 안됩니다.
(현재 요청드린 상태 입니다.)
<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->
