### PR TITLE
refactor:stompClient context로 분리 후 채팅방에 적용

### DIFF
--- a/src/components/chat/ChatDetail.tsx
+++ b/src/components/chat/ChatDetail.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { Client } from '@stomp/stompjs';
 
 import { client } from '@/apis';
 import { ProductInfo, SellerInfo, UserInfo } from '@/components/chat/Chat';
@@ -7,6 +6,7 @@ import ChatDetailBody from '@/components/chat/chatDetail/ChatDetailBody';
 import ChatDetailHeader from '@/components/chat/chatDetail/ChatDetailHeader';
 import ChatSend from '@/components/chat/chatDetail/ChatSend';
 import { useChat } from '@/hooks/useChat';
+import { useStompClient } from '@/hooks/useStompClient';
 import { Message } from '@/models/chat';
 
 export type ChatUserProps = {
@@ -30,11 +30,7 @@ const ChatDetail = ({
   clickPrevButton,
   handleOpen,
 }: ChatUserProps) => {
-  const [stompClient] = useState(
-    new Client({
-      brokerURL: `${import.meta.env.VITE_API_CHAT_URL}/chat`,
-    }),
-  );
+  const stompClient = useStompClient();
 
   // 이전의 메세지 기록 담기
   const [prevMessage, setPrevMessage] = useState<Message[]>([]);
@@ -48,13 +44,10 @@ const ChatDetail = ({
     stompClient,
   });
 
-  console.log('GYU MSG', message);
-
   const loadPrevChat: () => Promise<void> = async () => {
     await client
       .get(`/v1/api/chat/detail/${customRoomId}`)
       .then((res) => {
-        console.log(res);
         const data = res.data.chats;
         const prevMessage: Message[] = Object.values(data);
         setPrevMessage([...prevMessage]);

--- a/src/context/StompClientProvider.tsx
+++ b/src/context/StompClientProvider.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import React, { createContext } from 'react';
+import { Client } from '@stomp/stompjs';
+
+type Props = {
+  children: React.ReactNode;
+};
+// createContext를 사용하여 새로운 Context를 생성합니다.
+export const StompClient = createContext<Client | null>(null);
+
+// 컴포넌트를 감싸고 있는 컨텍스트를 제공하는 컴포넌트를 생성합니다.
+const StompClientProvider = ({ children }: Props) => {
+  // 새로운 stompClient 인스턴스를 생성합니다.
+  const [stompClient] = useState(
+    new Client({
+      brokerURL: `${import.meta.env.VITE_API_CHAT_URL}/chat`,
+    }),
+  );
+
+  return <StompClient.Provider value={stompClient}>{children}</StompClient.Provider>;
+};
+
+export default StompClientProvider;

--- a/src/hooks/useStompClient.ts
+++ b/src/hooks/useStompClient.ts
@@ -4,6 +4,6 @@ import { Client } from '@stomp/stompjs';
 import { StompClient } from '@/context/StompClientProvider';
 
 // 커스텀 Hook을 생성하여 stompClient 인스턴스를 가져옵니다.
-export function useStompClient(): Client | null {
+export const useStompClient = (): Client | null => {
   return useContext(StompClient);
-}
+};

--- a/src/hooks/useStompClient.ts
+++ b/src/hooks/useStompClient.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import { Client } from '@stomp/stompjs';
+
+import { StompClient } from '@/context/StompClientProvider';
+
+// 커스텀 Hook을 생성하여 stompClient 인스턴스를 가져옵니다.
+export function useStompClient(): Client | null {
+  return useContext(StompClient);
+}

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter } from 'react-router-dom';
 import { Purchase } from '@/components/Mypage-Purchase/Purchase';
 import { SoldPage } from '@/components/Mypage-Sold/SoldPage';
 import { WishPage } from '@/components/Mypage-Wish/WishPage';
+import StompClientProvider from '@/context/StompClientProvider';
 import { AddProduct } from '@/pages/AddProduct/AddProduct.tsx';
 import { CartPage } from '@/pages/CartPage/CartPage';
 import Menu from '@/pages/Category/Menu';
@@ -38,7 +39,11 @@ export const router = createBrowserRouter([
       },
       {
         path: '/product/:productId',
-        element: <DetailPage />,
+        element: (
+          <StompClientProvider>
+            <DetailPage />
+          </StompClientProvider>
+        ),
       },
       {
         path: '/category',


### PR DESCRIPTION
close #211

## 💡 개요
stompClient 채팅관련 스코프내에 전역으로 관리
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 📝 작업 내용
1. context로 stompClient 소켓 생성부분 빼내기
2. 기존 객체 삭제 후 chatDetail에 적용.
<!-- 작업한 UI 있으면 UI 첨부 -->
<!-- 작업 내용 -->

## ‼️ 주의 사항

<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->
