### PR TITLE
feat#226 chatlist sse 적용

### DIFF
--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import ChatButton from '@/components/chat/ChatButton';
 import ChatDetail from '@/components/chat/ChatDetail';
@@ -44,7 +44,7 @@ const Chat = ({
   const seller: SellerInfo = { sellerId: sellerId, shopName: sellerName };
   const product: ProductInfo = { productId: productId, productName: productName };
   const [user, setUser] = useState<UserInfo>({ userId: userId, userName: userName });
-  const [isCustomRoomId, setIsCustomRoomId] = useState<boolean>(true);
+  const [isNowChatRoom, setIsNowChatRoom] = useState<boolean>(false);
 
   const isSeller = isUser;
   const role = isSeller ? 'seller' : 'user';
@@ -65,20 +65,19 @@ const Chat = ({
     return customRoomId;
   }
 
-  /** clickPrevButton() : 채팅방에서 뒤로가기 버튼 누르면
-   * 1. 분기처리를 위해 customRoomId값을 빈 스트링을 넣는다. */
+  /** clickPrevButton() : 채팅방에서 뒤로가기 버튼 */
   const clickPrevButton = () => {
-    setCustomRoomId('');
+    setIsNowChatRoom((prev) => !prev);
   };
 
   /** clickListBox() : 채팅list에서 해당 채팅방으로 들어가기 위해
-   * 1. isCustomRoomId를 false,
+   * 1. isNowChatRoom를 false,
    * 2. ChatBody.tsx에서 custumroomId를 받아와서 ChatList.tsx로 넘겨줌.
    * 3. seller일때 현재 디테일에서 넘어오는 userId, userName값은 판매자의 정보여서 ChatList.tsx에서
         문의한 구매자의 userId값, userName값을 가져옴.
    */
   const clickListBox = (customRoomId: string, userId: number, userName: string) => {
-    setIsCustomRoomId((prev) => !prev);
+    setIsNowChatRoom((prev) => !prev);
     setCustomRoomId(customRoomId);
     setUser({ ...user, userId, userName });
   };
@@ -87,18 +86,12 @@ const Chat = ({
     setIsModalOpen((prev) => !prev);
   };
 
-  useEffect(() => {
-    if (customRoomId.length === 0) {
-      setIsCustomRoomId((prev) => !prev);
-    }
-  }, [customRoomId]);
-
   return (
     <>
       <ChatButton handleOpen={handleOpen} />
       {isModalOpen && isSeller && (
         <S.Chat>
-          {isCustomRoomId ? (
+          {!isNowChatRoom ? (
             <ChatList
               customRoomId={customRoomId}
               handleOpen={handleOpen}
@@ -124,7 +117,7 @@ const Chat = ({
       )}
       {isModalOpen && !isSeller && (
         <S.Chat>
-          {!isCustomRoomId ? (
+          {isNowChatRoom ? (
             <ChatList
               customRoomId={customRoomId}
               handleOpen={handleOpen}

--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -100,10 +100,12 @@ const Chat = ({
         <S.Chat>
           {isCustomRoomId ? (
             <ChatList
+              customRoomId={customRoomId}
               handleOpen={handleOpen}
               clickListBox={clickListBox}
               seller={seller}
               isSeller={isSeller}
+              role={role}
               product={product}
             />
           ) : (
@@ -124,10 +126,12 @@ const Chat = ({
         <S.Chat>
           {!isCustomRoomId ? (
             <ChatList
+              customRoomId={customRoomId}
               handleOpen={handleOpen}
               clickListBox={clickListBox}
               seller={seller}
               isSeller={isSeller}
+              role={role}
               product={product}
             />
           ) : (

--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -71,7 +71,7 @@ const Chat = ({
   };
 
   /** clickListBox() : 채팅list에서 해당 채팅방으로 들어가기 위해
-   * 1. isNowChatRoom를 false,
+   * 1. isNowChatRoom로 분기처리,
    * 2. ChatBody.tsx에서 custumroomId를 받아와서 ChatList.tsx로 넘겨줌.
    * 3. seller일때 현재 디테일에서 넘어오는 userId, userName값은 판매자의 정보여서 ChatList.tsx에서
         문의한 구매자의 userId값, userName값을 가져옴.
@@ -93,10 +93,10 @@ const Chat = ({
         <S.Chat>
           {!isNowChatRoom ? (
             <ChatList
-              customRoomId={customRoomId}
               handleOpen={handleOpen}
               clickListBox={clickListBox}
               seller={seller}
+              user={user}
               isSeller={isSeller}
               role={role}
               product={product}
@@ -119,10 +119,10 @@ const Chat = ({
         <S.Chat>
           {isNowChatRoom ? (
             <ChatList
-              customRoomId={customRoomId}
               handleOpen={handleOpen}
               clickListBox={clickListBox}
               seller={seller}
+              user={user}
               isSeller={isSeller}
               role={role}
               product={product}

--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -41,6 +41,7 @@ const Chat = ({
   isUser,
   shopImageUrl,
 }: ChatProps) => {
+  // TODO: 커스텀 훅으로 빼기.
   const seller: SellerInfo = { sellerId: sellerId, shopName: sellerName };
   const product: ProductInfo = { productId: productId, productName: productName };
   const [user, setUser] = useState<UserInfo>({ userId: userId, userName: userName });
@@ -84,7 +85,10 @@ const Chat = ({
 
   const handleOpen = () => {
     setIsModalOpen((prev) => !prev);
+    setIsNowChatRoom(false);
   };
+
+  console.log('isNowChatRoom', isNowChatRoom);
 
   return (
     <>

--- a/src/components/chat/ChatList.tsx
+++ b/src/components/chat/ChatList.tsx
@@ -24,7 +24,7 @@ export type List = {
   lastChat: Message;
 };
 
-type chatProps = {
+type ChatProps = {
   clickListBox: (customRoomId: string, userId: number, userName: string) => void;
   handleOpen: () => void;
   seller: {
@@ -48,23 +48,18 @@ const ChatList = ({
   isSeller,
   product,
   role,
-}: chatProps) => {
+}: ChatProps) => {
   const [list, setList] = useState<List[]>([]);
-
   const [shopImg, setShopImg] = useState<string>('');
 
   const message = useSSE(role, seller.sellerId, user.userId);
-  console.log('chatListMessage', message);
 
-  // useEffect(() => {
-  //   setList([...message]);
-  // }, []);
-
+  //TODO: 리액트쿼리로 변경하기
   const loadUserChatList: () => Promise<void> = async () => {
-    const sellerId = seller.sellerId;
-    userChatList(sellerId)
+    userChatList(seller.sellerId)
       .then((resData) => {
         const data = resData.chatList;
+        console.log('list', data);
         const img = resData.shopImage;
         setList([...data]);
         setShopImg(img);
@@ -80,6 +75,7 @@ const ChatList = ({
     sellerChatList(sellerId, productId)
       .then((resData) => {
         const data = resData.chatList;
+        console.log('list', data);
         const img = resData.shopImage;
         setList([...data]);
         setShopImg(img);
@@ -95,10 +91,10 @@ const ChatList = ({
   }, [isSeller]);
 
   return (
-    <div>
+    <>
       <ChatHeader shopName={seller.shopName} shopImg={shopImg} handleOpen={handleOpen} />
-      <ChatBody chatList={list} clickListBox={clickListBox} />
-    </div>
+      <ChatBody chatList={list} clickListBox={clickListBox} newMessage={message} />
+    </>
   );
 };
 

--- a/src/components/chat/ChatList.tsx
+++ b/src/components/chat/ChatList.tsx
@@ -4,7 +4,7 @@ import { sellerChatList, userChatList } from '@/apis/chat';
 import ChatBody from '@/components/chat/chatList/ChatBody';
 import ChatHeader from '@/components/chat/chatList/ChatHeader';
 import { useSSE } from '@/hooks/useSSE';
-import { Message } from '@/models/chat';
+import { Message, UserInfo } from '@/models/chat';
 
 export type Chat = {
   [timestamp: string]: Message;
@@ -31,31 +31,34 @@ type chatProps = {
     sellerId: number;
     shopName: string;
   };
+  user: UserInfo;
   product: {
     productId: number;
     productName: string;
   };
   isSeller: boolean;
   role: string;
-  customRoomId: string;
 };
 
 const ChatList = ({
   handleOpen,
   clickListBox,
   seller,
+  user,
   isSeller,
   product,
-  customRoomId,
   role,
 }: chatProps) => {
   const [list, setList] = useState<List[]>([]);
 
   const [shopImg, setShopImg] = useState<string>('');
 
-  const message = useSSE(customRoomId, role);
+  const message = useSSE(role, seller.sellerId, user.userId);
+  console.log('chatListMessage', message);
 
-  console.log(message);
+  // useEffect(() => {
+  //   setList([...message]);
+  // }, []);
 
   const loadUserChatList: () => Promise<void> = async () => {
     const sellerId = seller.sellerId;

--- a/src/components/chat/ChatList.tsx
+++ b/src/components/chat/ChatList.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { sellerChatList, userChatList } from '@/apis/chat';
 import ChatBody from '@/components/chat/chatList/ChatBody';
 import ChatHeader from '@/components/chat/chatList/ChatHeader';
+import { useSSE } from '@/hooks/useSSE';
 import { Message } from '@/models/chat';
 
 export type Chat = {
@@ -35,12 +36,26 @@ type chatProps = {
     productName: string;
   };
   isSeller: boolean;
+  role: string;
+  customRoomId: string;
 };
 
-const ChatList = ({ handleOpen, clickListBox, seller, isSeller, product }: chatProps) => {
+const ChatList = ({
+  handleOpen,
+  clickListBox,
+  seller,
+  isSeller,
+  product,
+  customRoomId,
+  role,
+}: chatProps) => {
   const [list, setList] = useState<List[]>([]);
 
   const [shopImg, setShopImg] = useState<string>('');
+
+  const message = useSSE(customRoomId, role);
+
+  console.log(message);
 
   const loadUserChatList: () => Promise<void> = async () => {
     const sellerId = seller.sellerId;

--- a/src/components/chat/chatList/ChatBody.tsx
+++ b/src/components/chat/chatList/ChatBody.tsx
@@ -1,13 +1,15 @@
 import { List } from '@/components/chat/ChatList';
 import ChatBox from '@/components/chat/chatList/ChatBox';
+import { ChatAlarm } from '@/hooks/useSSE';
 import * as S from '../Chat.styles';
 
 type ChatBodyProps = {
   chatList: List[];
   clickListBox: (customRoomId: string, userId: number, userName: string) => void;
+  newMessage?: ChatAlarm;
 };
 
-const ChatBody = ({ chatList, clickListBox }: ChatBodyProps) => {
+const ChatBody = ({ chatList, clickListBox, newMessage }: ChatBodyProps) => {
   return (
     <S.ChatBody>
       {chatList?.map((item, idx) => {
@@ -17,7 +19,11 @@ const ChatBody = ({ chatList, clickListBox }: ChatBodyProps) => {
             key={idx}
           >
             <ChatBox
-              lastChat={item.lastChat.content}
+              lastChat={
+                newMessage?.customRoomId === item.customRoomId
+                  ? newMessage?.content
+                  : item.lastChat.content
+              }
               sender={item?.lastChat.sender}
               productName={item.productName}
               image={item.imageUrl}

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
-type chatAlarm = {
+export type ChatAlarm = {
   content: string;
   createAt: string;
   customRoomId: string;
@@ -9,34 +9,37 @@ type chatAlarm = {
   sender: string;
 };
 
+//TODO: useSSE를 쓰는 컴포넌트에서 두번 렌더링 되는 이유 찾기.(최상단부터 뒤져보기)
 export const useSSE = (role: string, sellerId: number, userId: number) => {
-  const [message, setMessage] = useState<chatAlarm>();
+  const [message, setMessage] = useState<ChatAlarm>();
 
   const isUser =
     role === 'user'
       ? `${import.meta.env.VITE_API_SSE_URL}/chat-alarm/${role}/${sellerId}/${userId}`
       : `${import.meta.env.VITE_API_SSE_URL}/chat-alarm/${role}/${sellerId}`;
 
-  const eventSource = new EventSource(isUser);
-  console.log('EventSource opened');
+  const [eventSource] = useState(() => new EventSource(isUser));
 
-  eventSource.addEventListener('sse', function (event) {
-    const message = JSON.parse(event.data);
-    console.log('새로운 채팅 알람: ', message);
-    setMessage({ ...message });
-  });
+  useEffect(() => {
+    console.log('되나', eventSource);
+    eventSource.addEventListener('sse', function (event) {
+      const message = JSON.parse(event.data);
+      console.log('새로운 채팅 알람: ', message);
+      setMessage({ ...message });
+    });
 
-  eventSource.onerror = function (error) {
-    console.error('EventSource failed:', error);
-    eventSource.close();
-  };
-
-  window.addEventListener('unload', function () {
-    if (eventSource) {
+    eventSource.onerror = function (error) {
+      console.error('EventSource failed:', error);
       eventSource.close();
-      console.log('EventSource closed');
-    }
-  });
+    };
+
+    window.addEventListener('unload', function () {
+      if (eventSource) {
+        eventSource.close();
+        console.log('EventSource closed');
+      }
+    });
+  }, []);
 
   return message;
 };

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+type chatAlarm = {
+  content: string;
+  createAt: string;
+  customRoomId: string;
+  role: string;
+  sellerId: number;
+  sender: string;
+};
+
+export const useSSE = (customRoomId: string, role: string) => {
+  console.log('useSSE', customRoomId);
+  console.log('role', role);
+  const [message, setMessage] = useState<chatAlarm[]>([]);
+
+  console.log(message);
+
+  useEffect(() => {
+    const eventSource = new EventSource(
+      `${import.meta.env.VITE_API_SSE_URL}/chat-alarm/${role}/${customRoomId}`,
+    );
+
+    eventSource.addEventListener('sse', function (event) {
+      const message = JSON.parse(event.data);
+      console.log('새로운 채팅 알람: ', message);
+      setMessage((prevMessages) => [...prevMessages, message]);
+    });
+
+    eventSource.onerror = function (error) {
+      console.error('EventSource failed:', error);
+      eventSource.close();
+    };
+
+    window.addEventListener('unload', function () {
+      if (eventSource) {
+        eventSource.close();
+        console.log('EventSource closed');
+      }
+    });
+
+    return () => {
+      eventSource.close();
+      console.log('EventSource closed');
+    };
+  }, [customRoomId, role]);
+
+  return message;
+};


### PR DESCRIPTION
close #226

## 💡 개요
채팅리스트에 실시간으로 오는 마지막 채팅을 보여주기 위한 작업입니다.

채팅리스트 미리보기에 Sse를 사용한 이유는
1. 클라이언트 쪽에서 데이터를 보낼것이 없음.
2. sse가 소켓보다 가볍기 때문.
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 📝 작업 내용
1. 적용할 sse를 커스텀 훅으로 생성
2. sse가 return한 message값으로 해당하는 list contents 업데이트

3. message값으로 list contents 업데이트시 chatlist의 모든 컴포넌트들이 재렌더링됨.

https://github.com/supercoding-commerce/FE/assets/100771469/53b2cf40-527f-4608-aabf-a3b809db6f67

이유를 찾아보니 커스텀훅의 상태를 변경하면 해당 훅을 사용하는 컴포넌트도 리렌더링 되기 때문.
내가 useSSE를 사용하는 위치가 chatList의 최상단 컴포넌트였기 때문에 모든 컴포넌트들이 재렌더링이 되었음.
그래서 useSSE를 chatBody.tsx로 옮겨서 사용.

https://github.com/supercoding-commerce/FE/assets/100771469/5655eed4-85c4-4ef8-985c-56a42cf09a2d




<!-- 작업한 UI 있으면 UI 첨부 -->
<!-- 작업 내용 -->

## ‼️ 주의 사항

<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->
