### PR TITLE
feat: api 토큰 만료시 로그아웃 기능 구현

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,7 +1,8 @@
-import axios, { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 import { localStorageKey } from '@/constants';
 import { getItem, setItem } from '@/utils/localstorage';
+import { removeItem } from '@/utils/localstorage.ts';
 
 const BASE_URL: string = import.meta.env.VITE_API_BASE_URL;
 
@@ -28,21 +29,46 @@ client.interceptors.request.use(
   },
 );
 
-client.interceptors.response.use((response: AxiosResponse): AxiosResponse => {
-  const accessToken: string | null = response.data.accessToken;
-  const refreshToken: string | null = response.data.refreshToken;
-  const editToken = (token: string) => {
-    const editedToken = token.replace('Bearer', '').trim();
-    return editedToken;
-  };
+client.interceptors.response.use(
+  (response: AxiosResponse): AxiosResponse => {
+    const accessToken: string | null = response.data.accessToken;
+    const refreshToken: string | null = response.data.refreshToken;
+    const editToken = (token: string) => {
+      const editedToken = token.replace('Bearer', '').trim();
+      return editedToken;
+    };
 
-  if (accessToken) {
-    setItem(localStorageKey.accessToken, editToken(accessToken));
-  }
+    if (accessToken) {
+      setItem(localStorageKey.accessToken, editToken(accessToken));
+    }
 
-  if (refreshToken) {
-    setItem(localStorageKey.refreshToken, editToken(refreshToken));
-  }
+    if (refreshToken) {
+      setItem(localStorageKey.refreshToken, editToken(refreshToken));
+    }
 
-  return response;
-});
+    return response;
+  },
+  (error: AxiosError<ErrorResponse>) => {
+    const handelSignOut = () => {
+      removeItem(localStorageKey.accessToken);
+      removeItem(localStorageKey.refreshToken);
+      removeItem(localStorageKey.user);
+    };
+    // GYU-TODO: 400 code 로 오는데 401, 또는 403 으로 변경 가능한지 요청하기!
+    // ACCESS_TOKEN 만료, REFRESH_TOKEN 만료 정확히 어떻게 오는지 백엔드랑 논의 후 업데이트
+    if (
+      error.response?.data.errorMessage === 'RefreshToken Expired' ||
+      error.response?.status === 403
+    ) {
+      // TODO-GYU: ACCESS_TOKEN 만료시, 토큰갱신(refresh 토큰을 이용하여) 로직 개선
+      // TODO-GYU: 리프레쉬토큰 만료시 로그아웃 하기!
+      // - 현재는 인증에러 나면 바로 로그아웃 조치
+      handelSignOut();
+    }
+  },
+);
+
+export interface ErrorResponse {
+  code: string;
+  errorMessage: string;
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,5 @@
 export const localStorageKey = {
   accessToken: 'ACCESS_TOKEN',
   refreshToken: 'REFRESH_TOKEN',
+  user: 'USER',
 };

--- a/src/recoil/userState.ts
+++ b/src/recoil/userState.ts
@@ -1,7 +1,11 @@
 import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 
-const { persistAtom } = recoilPersist();
+import { localStorageKey } from '@/constants';
+
+const { persistAtom } = recoilPersist({
+  key: localStorageKey.user,
+});
 
 export interface UserType {
   email: string;


### PR DESCRIPTION
close #228 

## 💡 개요
- 현재 백엔드에서 accessToken, refreshToken 기능이 제대로 동작하지 않음, 그래서 token 만료가 되면 로그아웃 기능 추가  
  추후 백엔드에서 token 에 따른 로직을 추가하면 변경 예정


## 📝 작업 내용
- token 만료가 되면 로그아웃이 된다.

## ‼️ 주의 사항
- 현재 detailPage 에서 getInfo 등 accessToken 이 필요한 api 요청을하는데 ProtectedRoute 로 감싸지 않아서 로그아웃 호출해도 해당 페이지 접근합니다.
- 이거 기획적으로 어떻게 풀건지 궁금합니다! (@cho-subin @heelws)